### PR TITLE
Warning: Please use require("history").createBrowserHistory instead o…

### DIFF
--- a/client/src/history.js
+++ b/client/src/history.js
@@ -1,2 +1,2 @@
-import createHistory from 'history/createBrowserHistory'
-export default createHistory()
+import { createBrowserHistory } from "history";
+export default createBrowserHistory();


### PR DESCRIPTION
…f require("history/createBrowserHistory"). Support for the latter will be removed in the next major release.